### PR TITLE
Adicionado prop "step" que estava faltando

### DIFF
--- a/src/components/Input.vue
+++ b/src/components/Input.vue
@@ -42,6 +42,7 @@
           placeholder,
           required,
           readOnly,
+          step,
           rows,
           type: inputType,
         }"
@@ -115,6 +116,13 @@ export default {
     minLength: {
       type: [String, Number],
       default: null,
+    },
+     /**
+     * _Validação:_ Intervalo numérico minimo 
+     */
+    step: {
+      type: Number,
+      default: 1,
     },
     /**
      * _Validação:_ Valida contra uma expressão regular


### PR DESCRIPTION
Added step prop which was missing - Adicionado prop "step" que estava faltando
Set default to 1 and type to Number - Colocado default em 1 e tipo como "number"
Needs testing - Precisa ser testado

## Related Tickets

* [Vi-Input type number doesn't accept decimal step](https://github.com/vitta-health/Vi-Ui/issues/48)


## Todos

- [ ] Tests
